### PR TITLE
Fix two bugs with subframe decoding

### DIFF
--- a/frame/subframe.go
+++ b/frame/subframe.go
@@ -383,7 +383,7 @@ func (subframe *Subframe) decodeRicePart(paramSize uint) error {
 		if err != nil {
 			return unexpected(err)
 		}
-		if paramSize == 4 && x == 0xF || paramSize == 4 && x == 0x1F {
+		if paramSize == 4 && x == 0xF || paramSize == 5 && x == 0x1F {
 			// 1111 or 11111: Escape code, meaning the partition is in unencoded
 			// binary form using n bits per sample; n follows as a 5-bit number.
 			panic("not yet implemented; Rice parameter escape code.")
@@ -446,11 +446,11 @@ func (subframe *Subframe) decodeLPC(coeffs []int32, shift int32) error {
 		panic("not yet implemented; negative shift.")
 	}
 	for i := subframe.Order; i < subframe.NSamples; i++ {
-		var sample int32
+		var sample int64
 		for j, c := range coeffs {
-			sample += c * subframe.Samples[i-j-1]
+			sample += int64(c) * int64(subframe.Samples[i-j-1])
 		}
-		subframe.Samples[i] += sample >> uint(shift)
+		subframe.Samples[i] += int32(sample >> uint(shift))
 	}
 	return nil
 }


### PR DESCRIPTION
Fix two bugs with subframe decoding in the FLAC library:

* the linear predictive coding has an overflow error -- with FIR-encoded frames, this often causes the output signal to be noise rather than what it should be. Type-converting to int64 to do the summation, then back to int32 after shifting fixed this for the files that I tested against.

* the check if the Rice parameter was the escape code did not handle the 5-bit escape code -- it checked for 0x1f and a 4-bit-long code instead of a 5-bit-long one

I don't have any FLAC files that test the latter issue; I have a number of FLAC files that caused the former, all of which were very noisy before and are sonically correct now.