### PR TITLE
fix/flac: Actually print relevant incorrect type

### DIFF
--- a/flac.go
+++ b/flac.go
@@ -184,7 +184,7 @@ func (stream *Stream) parseStreamInfo() (block *meta.Block, err error) {
 	}
 	si, ok := block.Body.(*meta.StreamInfo)
 	if !ok {
-		return block, fmt.Errorf("flac.parseStreamInfo: incorrect type of first metadata block; expected *meta.StreamInfo, got %s", block.Header.Type)
+		return block, fmt.Errorf("flac.parseStreamInfo: incorrect type of first metadata block; expected *meta.StreamInfo, got %T", block.Body)
 	}
 	stream.Info = si
 	return block, nil

--- a/flac.go
+++ b/flac.go
@@ -184,7 +184,7 @@ func (stream *Stream) parseStreamInfo() (block *meta.Block, err error) {
 	}
 	si, ok := block.Body.(*meta.StreamInfo)
 	if !ok {
-		return block, fmt.Errorf("flac.parseStreamInfo: incorrect type of first metadata block; expected *meta.StreamInfo, got %T", si)
+		return block, fmt.Errorf("flac.parseStreamInfo: incorrect type of first metadata block; expected *meta.StreamInfo, got %s", block.Header.Type)
 	}
 	stream.Info = si
 	return block, nil


### PR DESCRIPTION
`si` will always be `(*meta.StreamInfo)`, the relevant type is
`block.Header.Type` which implements `Stringer`