### PR TITLE
Fix integer overflow during unfolding of the rice residual

### DIFF
--- a/frame/subframe.go
+++ b/frame/subframe.go
@@ -443,10 +443,10 @@ func (subframe *Subframe) decodeRiceResidual(br *bits.Reader, k uint) error {
 	if err != nil {
 		return unexpected(err)
 	}
-	residual := int32(high<<k | low)
+	folded := uint32(high<<k | low)
 
 	// ZigZag decode.
-	residual = bits.ZigZag(residual)
+	residual := bits.ZigZag(folded)
 	subframe.Samples = append(subframe.Samples, residual)
 
 	return nil

--- a/internal/bits/zigzag.go
+++ b/internal/bits/zigzag.go
@@ -14,6 +14,6 @@ package bits
 //	6 =>  3
 //
 // ref: https://developers.google.com/protocol-buffers/docs/encoding
-func ZigZag(x int32) int32 {
-	return x>>1 ^ -(x & 1)
+func ZigZag(x uint32) int32 {
+	return int32(x>>1) ^ -int32(x&1)
 }


### PR DESCRIPTION
Solves https://github.com/mewkiz/flac/issues/60

Fix found by looking really hard at the reference code:
https://github.com/xiph/flac/blob/8cf7e7fbb536e3968efe1e442922c514ca99f9c0/src/libFLAC/deduplication/bitreader_read_rice_signed_block.c#L91