### PR TITLE
Fail the Github Action step when gofmt fails

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,11 @@ jobs:
         run: go test -v -covermode atomic -coverprofile=covprofile ./...
 
       - name: Gofmt
-        run: gofmt -d ./
+        # Run gofmt, print the output and exit with status code 1 if it isn't empty.
+        run: |
+          OUTPUT=$(gofmt -d ./)
+          echo "$OUTPUT"
+          test -z "$OUTPUT"
 
       - name: Send coverage
         if: ${{ matrix.go-version == 'stable' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
In an oversight I hadn't noticed that gofmt doesn't change its exit code when the code isn't properly formatted. This PR captures the output and manually tests it to return a proper exit code to make the pipeline fail if something isn't right.