### PR TITLE
feat: [FLAC] drop io.Closer element in Stream and Encoder types

### DIFF
--- a/encode_frame.go
+++ b/encode_frame.go
@@ -115,7 +115,9 @@ func (enc *Encoder) encodeFrameHeader(w io.Writer, hdr frame.Header) error {
 	h := crc8.NewATM()
 	hw := io.MultiWriter(h, w)
 	bw := bitio.NewWriter(hw)
-	enc.c = bw
+
+	// Closing the *bitio.Writer will not close the underlying writer
+	defer bw.Close()
 
 	//  Sync code: 11111111111110
 	if err := bw.WriteBits(0x3FFE, 14); err != nil {


### PR DESCRIPTION
The `io.Closer` type is taken only if the underlying `io.Reader` (for `Stream`) and `io.Writer` (for `Encoder`) implements `io.Closer`.

This being the case, there is no point in storing it as an additional element in these data structures. It both makes them simpler and shorter (minus one pointer type, considering that interfaces are stored as pointer types), and it also makes the code a bit more readable.

Another detail is the change in the encoder frames logic, which initializes a `bitio.Writer` which wraps our Encoder's writer, and the Encoder's closer is replaced with the `bitio.Writer` instance -- however, `bitio.Writer.Closer` does not close the underlying writer.