### PR TITLE
Fix seek to frame start

### DIFF
--- a/flac.go
+++ b/flac.go
@@ -343,7 +343,7 @@ func (stream *Stream) Seek(sampleNum uint64) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		if frame.SampleNumber()+uint64(frame.BlockSize) >= sampleNum {
+		if frame.SampleNumber()+uint64(frame.BlockSize) > sampleNum {
 			// Restore seek offset to the start of the frame containing the
 			// specified sample number.
 			_, err := rs.Seek(offset, io.SeekStart)

--- a/flac_test.go
+++ b/flac_test.go
@@ -48,6 +48,8 @@ func TestSeek(t *testing.T) {
 		{seek: 0, expected: 0},
 		{seek: 50000, expected: 0, err: "unable to seek to sample number 50000"},
 		{seek: 100, expected: 0},
+		{seek: 8192, expected: 8192},
+		{seek: 8191, expected: 4096},
 	}
 
 	stream, err := flac.NewSeek(f)


### PR DESCRIPTION
This PR fixes that seeking to the exact start of a frame seeks to that frame instead of the previous one.