### PR TITLE
Add optional FLAC compression

### DIFF
--- a/analysis_fixed.go
+++ b/analysis_fixed.go
@@ -1,0 +1,183 @@
+package flac
+
+import (
+	"github.com/mewkiz/flac/frame"
+	iobits "github.com/mewkiz/flac/internal/bits"
+)
+
+// analyseFixed selects the best fixed predictor (order 0-4) for the given
+// subframe and fills the fields required by the existing writer so that a
+// compressed SUBFRAME_FIXED is emitted instead of a verbatim subframe.
+//
+// The algorithm is a very small subset of libFLAC's encoder analysis:
+//  1. For each order 0..4 compute residuals using the fixed coefficients
+//     defined in frame.FixedCoeffs.
+//  2. For those residuals, choose the Rice parameter k (0..14) that minimises
+//     the encoded bit-length assuming partition order 0.
+//  3. Pick the order with the overall fewest bits.
+//
+// ignoring partition orders >0 and Rice2 for now.
+func analyseFixed(sf *frame.Subframe, bps uint) {
+	// Guard against degenerate inputs. If there are fewer than two samples we
+	// simply keep verbatim encoding.
+	if len(sf.Samples) < 2 {
+		return
+	}
+
+	bestBits := int(^uint(0) >> 1) // max int
+	bestOrder := 0
+	bestK := uint(0)
+
+	// Try predictor orders 0 through 4.
+	for order := 0; order <= 4 && order < len(sf.Samples); order++ {
+		residuals := computeFixedResiduals(sf.Samples, order)
+		k := chooseRice(residuals)
+		bits := costFixed(order, bps, residuals, k)
+		if bits < bestBits {
+			bestBits = bits
+			bestOrder = order
+			bestK = k
+		}
+	}
+
+	// Populate subframe fields so the existing encode* routines can do their
+	// job. Warm-up samples are already present in sf.Samples.
+	sf.Pred = frame.PredFixed
+	sf.Order = bestOrder
+	sf.ResidualCodingMethod = frame.ResidualCodingMethodRice1
+	sf.RiceSubframe = &frame.RiceSubframe{
+		PartOrder:  0,
+		Partitions: []frame.RicePartition{{Param: bestK}},
+	}
+
+	// Note: We do NOT mutate sf.Samples. The encoder expects original samples
+	// because it recomputes residuals internally. The metadata we filled in is
+	// enough for encodeFixedSamples to reproduce the exact same residuals.
+}
+
+// computeFixedResiduals returns the residual signal for a given fixed
+// predictor order. The returned slice has length len(samples)-order.
+func computeFixedResiduals(samples []int32, order int) []int32 {
+	n := len(samples)
+	res := make([]int32, 0, n-order)
+
+	switch order {
+	case 0:
+		for i := 0; i < n; i++ {
+			res = append(res, samples[i])
+		}
+	case 1:
+		for i := 1; i < n; i++ {
+			res = append(res, samples[i]-samples[i-1])
+		}
+	case 2:
+		for i := 2; i < n; i++ {
+			predicted := 2*samples[i-1] - samples[i-2]
+			res = append(res, samples[i]-predicted)
+		}
+	case 3:
+		for i := 3; i < n; i++ {
+			predicted := 3*samples[i-1] - 3*samples[i-2] + samples[i-3]
+			res = append(res, samples[i]-predicted)
+		}
+	case 4:
+		for i := 4; i < n; i++ {
+			predicted := 4*samples[i-1] - 6*samples[i-2] + 4*samples[i-3] - samples[i-4]
+			res = append(res, samples[i]-predicted)
+		}
+	}
+	return res
+}
+
+// chooseRice returns the Rice parameter k (0..14) that minimises the encoded
+// length of residuals when using Rice coding with paramSize=4 (Rice1).
+func chooseRice(residuals []int32) uint {
+	bestK := uint(0)
+	bestBits := int(^uint(0) >> 1)
+
+	for k := uint(0); k < 15; k++ { // 15 is escape code, so evaluate 0..14
+		bits := 0
+		for _, r := range residuals {
+			folded := iobits.EncodeZigZag(r)
+			quo := folded >> k
+			bits += int(quo) + 1 + int(k) // unary + stop bit + k LSBs
+		}
+		if bits < bestBits {
+			bestBits = bits
+			bestK = k
+		}
+	}
+	return bestK
+}
+
+// costFixed returns the number of bits needed to code the subframe with the
+// given parameters. 6 bits for the subframe header are included so orders with
+// more warm-up samples are fairly compared.
+func costFixed(order int, bps uint, residuals []int32, k uint) int {
+	warmUpBits := order * int(bps)
+
+	// residual bits for chosen k
+	residBits := 0
+	for _, r := range residuals {
+		folded := iobits.EncodeZigZag(r)
+		quo := folded >> k
+		residBits += int(quo) + 1 + int(k)
+	}
+
+	// Subframe header is 6 bits + 1 wasted flag bit (always 0 here)
+	return 6 + warmUpBits + residBits
+}
+
+// analyseSubframe decides on the best prediction method (constant, verbatim, or fixed)
+// for a subframe that is currently marked PredVerbatim. It will update the Subframe
+// fields to use the chosen method. The heuristic is simple: it picks the encoding
+// that yields the fewest estimated bits when assuming a single Rice partition.
+func analyseSubframe(sf *frame.Subframe, bps uint) {
+	// Only analyse when the caller has not chosen a prediction method yet.
+	if sf.Pred != frame.PredVerbatim {
+		return
+	}
+
+	samples := sf.Samples
+	n := len(samples)
+	if n == 0 {
+		return
+	}
+
+	// --- Constant predictor cost.
+	allEqual := true
+	for i := 1; i < n; i++ {
+		if samples[i] != samples[0] {
+			allEqual = false
+			break
+		}
+	}
+	constBits := int(^uint(0) >> 1) // infinity
+	if allEqual {
+		// 6-bit header + one sample.
+		constBits = 6 + int(bps)
+	}
+
+	// --- Verbatim predictor cost.
+	verbatimBits := 6 + n*int(bps) // 6-bit header + raw samples
+
+	// --- Fixed predictor: reuse existing helper to find best order/k.
+	analyseFixed(sf, bps) // fills Order, RiceSubframe, etc.
+	// Cost of that choice
+	fixedBits := costFixed(sf.Order, bps, computeFixedResiduals(samples, sf.Order), sf.RiceSubframe.Partitions[0].Param)
+
+	// Choose the smallest.
+	if constBits < verbatimBits && constBits < fixedBits {
+		// Use constant encoding.
+		sf.Pred = frame.PredConstant
+		// No other metadata needed.
+	} else if fixedBits < verbatimBits {
+		// Keep fixed settings filled in by analyseFixed.
+		sf.Pred = frame.PredFixed
+	} else {
+		// Stick with verbatim – restore defaults that analyseFixed may have overwritten.
+		sf.Pred = frame.PredVerbatim
+		sf.Order = 0
+		sf.RiceSubframe = nil
+	}
+}

--- a/enc_benchmark_test.go
+++ b/enc_benchmark_test.go
@@ -1,0 +1,106 @@
+package flac
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/mewkiz/flac/frame"
+	"github.com/mewkiz/flac/meta"
+)
+
+// BenchmarkEncodeSyntheticAudio measures the performance of encoding synthetic audio data.
+// It creates a simple sine wave pattern to avoid dependency on external files.
+func BenchmarkEncodeSyntheticAudio(b *testing.B) {
+	// Create synthetic audio data (1 second of 44.1kHz stereo audio)
+	sampleRate := 44100
+	channels := 2
+	bitsPerSample := 16
+	numSamples := sampleRate
+
+	// Create StreamInfo
+	info := &meta.StreamInfo{
+		BlockSizeMin:  4096,
+		BlockSizeMax:  4096,
+		FrameSizeMin:  0,
+		FrameSizeMax:  0,
+		SampleRate:    uint32(sampleRate),
+		NChannels:     uint8(channels),
+		BitsPerSample: uint8(bitsPerSample),
+		NSamples:      uint64(numSamples),
+	}
+
+	// Generate synthetic audio data (sine wave)
+	samples := make([]int32, numSamples*channels)
+	freq := 440.0 // A4 note
+	for i := 0; i < numSamples; i++ {
+		// Generate a sine wave
+		sample := int32(math.Sin(2*math.Pi*freq*float64(i)/float64(sampleRate)) * 32767)
+		// Fill both channels with the same data
+		samples[i*2] = sample
+		samples[i*2+1] = sample
+	}
+
+	// Reset the timer before the actual benchmark
+	b.ResetTimer()
+
+	// Run the benchmark
+	for i := 0; i < b.N; i++ {
+		// Create a buffer to write the encoded data
+		buf := &bytes.Buffer{}
+
+		// Create encoder
+		enc, err := NewEncoder(buf, info)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		// Process samples in blocks
+		for offset := 0; offset < numSamples; offset += 4096 {
+			blockSize := 4096
+			if offset+blockSize > numSamples {
+				blockSize = numSamples - offset
+			}
+
+			// Create frame
+			fr := &frame.Frame{
+				Header: frame.Header{
+					HasFixedBlockSize: true,
+					BlockSize:         uint16(blockSize),
+					SampleRate:        uint32(sampleRate),
+					Channels:          frame.ChannelsLR,
+					BitsPerSample:     uint8(bitsPerSample),
+				},
+			}
+
+			// Create subframes
+			fr.Subframes = make([]*frame.Subframe, channels)
+			for ch := 0; ch < channels; ch++ {
+				// Extract samples for this channel
+				channelSamples := make([]int32, blockSize)
+				for j := 0; j < blockSize; j++ {
+					channelSamples[j] = samples[(offset+j)*channels+ch]
+				}
+
+				// Create verbatim subframe since we're just testing encoding speed
+				fr.Subframes[ch] = &frame.Subframe{
+					SubHeader: frame.SubHeader{
+						Pred: frame.PredVerbatim,
+					},
+					Samples:  channelSamples,
+					NSamples: blockSize,
+				}
+			}
+
+			// Encode frame
+			if err := enc.WriteFrame(fr); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		// Close encoder
+		if err := enc.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/encode.go
+++ b/encode.go
@@ -27,6 +27,8 @@ type Encoder struct {
 	// Current frame number if block size is fixed, and the first sample number
 	// of the current frame otherwise.
 	curNum uint64
+	// AnalysisEnabled indicates whether analysis is enabled for the encoder.
+	AnalysisEnabled bool
 }
 
 // NewEncoder returns a new FLAC encoder for the given metadata StreamInfo block
@@ -102,4 +104,8 @@ func (enc *Encoder) Close() error {
 		return closer.Close()
 	}
 	return nil
+}
+
+func (enc *Encoder) EnablePredictionAnalysis(enable bool) {
+	enc.AnalysisEnabled = enable
 }

--- a/encode_frame.go
+++ b/encode_frame.go
@@ -84,6 +84,13 @@ func (enc *Encoder) WriteFrame(f *frame.Frame) error {
 			}
 		}
 
+		// optional prediction analysis
+		if enc.AnalysisEnabled {
+			if subframe.Pred == frame.PredVerbatim {
+				analyseSubframe(subframe, bps)
+			}
+		} // when AnalysisEnabled is false we leave subframe as-is
+
 		if err := encodeSubframe(bw, f.Header, subframe, bps); err != nil {
 			return errutil.Err(err)
 		}

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -154,7 +154,12 @@ func (frame *Frame) Hash(md5sum hash.Hash) {
 	// Write decoded samples to a running MD5 hash.
 	bps := frame.BitsPerSample
 	var buf [3]byte
-	for i := 0; i < int(frame.BlockSize); i++ {
+	if len(frame.Subframes) == 0 {
+		return
+	}
+	// Use the length of the first subframe's samples as they should all be the same length
+	numSamples := len(frame.Subframes[0].Samples)
+	for i := 0; i < numSamples; i++ {
 		for _, subframe := range frame.Subframes {
 			sample := subframe.Samples[i]
 			switch {


### PR DESCRIPTION
Hi! I added the ability for the encoder to optionally choose a prediction method for better compression. I'm not sure the API is great but it seems to work and allows this library to produce files smaller than their input, see the Results at the end.

**Bonus:** The change in `frame.go` may be inappropriate for this PR but it fixes an out-of-index error I was getting in `wav2flac` on all files.

## How

Added an _opt-in_ prediction analysis pass.

- `Encoder` now has a boolean field `AnalysisEnabled` (helper `EnablePredictionAnalysis(true)`).
- When the flag is **off** (default) the encoder behaves as before: it writes Constant / Verbatim frames exactly as provided by the caller. This guarantees the round-trip tests that decode an existing FLAC and immediately re-encode it still pass.
- When the flag is **on** the encoder examines any sub-frame that is still marked `PredVerbatim` and chooses the smallest of:
  1. Constant predictor (all samples equal)
  2. Verbatim (no prediction)
  3. Fixed prediction. The new `analyseFixed()` picks the best order and Rice-k.

libFLAC exposes a range of parameters to tune the encoding process. This PR introduces one knob to try to pick the best prediction method.

## Results

Here's what I got when enabling prediction analysis on various audio files:

| File                   | Original Size | w/out analysis | w/ analysis | Reduction |
| ---------------------- | ------------- | -------------- | ----------- | --------- |
| forest_of_illusion.wav | 6.7 MB        | 7.9 MB         | 4.1 MB      | 48%       |
| yoshis_island.wav      | 4.8 MB        | 5.3 MB         | 2.6 MB      | 51%       |
| vanilla_dome.wav       | 8.5 MB        | 9.8 MB         | 5.9 MB      | 40%       |

There's an expected increase in encoding resources:

| Metric      | Before        | After         | Change           |
| ----------- | ------------- | ------------- | ---------------- |
| Time        | 1547070 ns/op | 6727643 ns/op | **4.35x slower** |
| Memory      | 1101783 B/op  | 3449681 B/op  | **3.13x more**   |
| Allocations | 244 allocs/op | 704 allocs/op | **2.89x more**   |

The new `enc_benchmark_test.go` created these results.

## Review
I'm open to feedback or questions, or if more tests are needed. I have no personal need for this, just thought it would be fun to try to enhance things a bit. 