### PR TITLE
fix allocation of very large blocks

### DIFF
--- a/meta/meta.go
+++ b/meta/meta.go
@@ -78,8 +78,9 @@ func Parse(r io.Reader) (block *Block, err error) {
 
 // Errors returned by Parse.
 var (
-	ErrReservedType = errors.New("meta.Block.Parse: reserved block type")
-	ErrInvalidType  = errors.New("meta.Block.Parse: invalid block type")
+	ErrReservedType        = errors.New("meta.Block.Parse: reserved block type")
+	ErrInvalidType         = errors.New("meta.Block.Parse: invalid block type")
+	ErrDeclaredBlockTooBig = errors.New("declared block size is too big to allocate")
 )
 
 // Parse reads and parses the metadata block body.

--- a/meta/picture.go
+++ b/meta/picture.go
@@ -2,8 +2,11 @@ package meta
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 )
+
+const maxPictureDataSize = 16 << 20 // 16 MB
 
 // Picture contains the image data of an embedded picture.
 //
@@ -111,6 +114,9 @@ func (block *Block) parsePicture() error {
 	}
 	if x == 0 {
 		return nil
+	}
+	if x > maxPictureDataSize {
+		return fmt.Errorf("meta.parsePicture: %w, picture data size=%d", ErrDeclaredBlockTooBig, x)
 	}
 
 	// (data length) bytes: Data.

--- a/meta/picture.go
+++ b/meta/picture.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-const maxPictureDataSize = 16 << 20 // 16 MB
+const maxPictureDataSize = 128 << 20 // 128 MB
 
 // Picture contains the image data of an embedded picture.
 //

--- a/meta/seektable.go
+++ b/meta/seektable.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+const maxSeekPoints = 10000
+
 // SeekTable contains one or more pre-calculated audio frame seek points.
 //
 // ref: https://www.xiph.org/flac/format.html#metadata_block_seektable
@@ -21,6 +23,9 @@ func (block *Block) parseSeekTable() error {
 	n := block.Length / 18
 	if n < 1 {
 		return errors.New("meta.Block.parseSeekTable: at least one seek point is required")
+	}
+	if n > maxSeekPoints {
+		return fmt.Errorf("meta.parseSeekTable: %w, number of seekpoints: %d", ErrDeclaredBlockTooBig, n)
 	}
 	table := &SeekTable{Points: make([]SeekPoint, n)}
 	block.Body = table

--- a/meta/seektable.go
+++ b/meta/seektable.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const maxSeekPoints = 10000
+const maxSeekPoints = 100000
 
 // SeekTable contains one or more pre-calculated audio frame seek points.
 //

--- a/meta/vorbiscomment.go
+++ b/meta/vorbiscomment.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const maxTags = 1024
+
 // VorbisComment contains a list of name-value pairs.
 //
 // ref: https://www.xiph.org/flac/format.html#metadata_block_vorbis_comment
@@ -38,6 +40,9 @@ func (block *Block) parseVorbisComment() (err error) {
 	// 32 bits: number of tags.
 	if err = binary.Read(block.lr, binary.LittleEndian, &x); err != nil {
 		return unexpected(err)
+	}
+	if x > maxTags {
+		return fmt.Errorf("meta.Block.parseVorbisComment: %w, tags number=%d", ErrDeclaredBlockTooBig, x)
 	}
 	if x < 1 {
 		return nil


### PR DESCRIPTION
# Description

Corrupt or malicious files may declare unreasonable large metadata blocks even if the actual data itself much smaller. Parser allocates buffers of the declared size when reading such files, and that may lead to out-of-memory errors.

# Ways to reproduce

I added testcase `TestVorbisCommentTooManyTagsOOM` to demostrate slowness and/or OOM after several iterations. In this PR it will pass because of the fix.

# Fix 

I added upper thresholds for number of tags in comment, number of seek points and raw picture size. If that threshold is hit, parsing fails with a `ErrDeclaredBlockTooBig` type error.

Thresholds are loose, and should accomodate any practical use case I can imagine. However, it should be difficult to exploit them now. 
